### PR TITLE
Fail nicely when trying to use petsc4py methods without petsc4py available

### DIFF
--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -54,7 +54,7 @@ else:
             raise ImportError(
                 f"Cannot load '{name}' from module '{__name__}' because "
                 "petsc4py is not available.\n"
-                "If this error appears during pip install then you may have"
+                "If this error appears during pip install then you may have "
                 "forgotten to pass --no-build-isolation"
             )
         else:

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -11,7 +11,9 @@ from .exceptions import PetscToolsException  # noqa: F401
 from .options import flatten_parameters  # noqa: F401
 from .utils import PETSC4PY_INSTALLED
 
-# Now conditionally import the functions that depend on petsc4py
+# Now conditionally import the functions that depend on petsc4py. If petsc4py
+# is not available then attempting to access these attributes will raise an
+# informative error.
 if PETSC4PY_INSTALLED:
     from .config import get_blas_library  # noqa: F401
     from .init import (  # noqa: F401
@@ -20,3 +22,18 @@ if PETSC4PY_INSTALLED:
         init,
     )
     from .options import OptionsManager  # noqa: F401
+else:
+    def __getattr__(name):
+        petsc4py_attrs = {
+            "get_blas_library",
+            "InvalidEnvironmentException",
+            "InvalidPetscVersionException",
+            "init",
+            "OptionsManager",
+        }
+        if name in petsc4py_attrs:
+            raise ImportError(
+                f"Cannot load '{name}' from module '{__name__}' because petsc4py "
+                "is not available"
+            )
+        raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -33,6 +33,7 @@ if PETSC4PY_INSTALLED:
         inserted_options,
     )
 else:
+
     def __getattr__(name):
         petsc4py_attrs = {
             "get_blas_library",
@@ -55,4 +56,6 @@ else:
                 "petsc4py is not available"
             )
         else:
-            raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")
+            raise AttributeError(
+                f"Module '{__name__}' has no attribute '{name}'"
+            )

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -54,4 +54,5 @@ else:
                 f"Cannot load '{name}' from module '{__name__}' because "
                 "petsc4py is not available"
             )
-        raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")
+        else:
+            raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -53,7 +53,9 @@ else:
         if name in petsc4py_attrs:
             raise ImportError(
                 f"Cannot load '{name}' from module '{__name__}' because "
-                "petsc4py is not available"
+                "petsc4py is not available.\n"
+                "If this error appears during pip install then you may have"
+                "forgotten to pass --no-build-isolation".
             )
         else:
             raise AttributeError(

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -55,7 +55,7 @@ else:
                 f"Cannot load '{name}' from module '{__name__}' because "
                 "petsc4py is not available.\n"
                 "If this error appears during pip install then you may have"
-                "forgotten to pass --no-build-isolation".
+                "forgotten to pass --no-build-isolation"
             )
         else:
             raise AttributeError(

--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -33,7 +33,7 @@ else:
         }
         if name in petsc4py_attrs:
             raise ImportError(
-                f"Cannot load '{name}' from module '{__name__}' because petsc4py "
-                "is not available"
+                f"Cannot load '{name}' from module '{__name__}' because "
+                "petsc4py is not available"
             )
         raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,9 @@ def pytest_collection_modifyitems(session, config, items):
             item.get_closest_marker("skippetsc4py") is not None
             and petsc4py_installed
         ):
-            item.add_marker(pytest.mark.skip(reason="Test requires not having petsc4py"))
+            item.add_marker(
+                pytest.mark.skip(reason="Test requires not having petsc4py")
+            )
 
         if (
             item.get_closest_marker("skipnopetsc4py") is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ import pytest
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
+        "skippetsc4py: mark as skipped unless petsc4py is not installed",
+    )
+    config.addinivalue_line(
+        "markers",
         "skipnopetsc4py: mark as skipped unless petsc4py is installed",
     )
 
@@ -17,6 +21,12 @@ def pytest_collection_modifyitems(session, config, items):
         petsc4py_installed = False
 
     for item in items:
+        if (
+            item.get_closest_marker("skippetsc4py") is not None
+            and petsc4py_installed
+        ):
+            item.add_marker(pytest.mark.skip(reason="Test requires not having petsc4py"))
+
         if (
             item.get_closest_marker("skipnopetsc4py") is not None
             and not petsc4py_installed

--- a/tests/test_no_petsc4py.py
+++ b/tests/test_no_petsc4py.py
@@ -1,0 +1,14 @@
+import petsctools
+import pytest
+
+
+@pytest.mark.skippetsc4py
+def test_import_error_raised_when_petsc4py_unavailable():
+    with pytest.raises(ImportError):
+        petsctools.init()
+
+    with pytest.raises(ImportError):
+        petsctools.OptionsManager({}, "prefix")
+
+    with pytest.raises(ImportError):
+        petsctools.get_blas_library()


### PR DESCRIPTION
This is particularly important for when someone forgets to pass `--no-build-isolation` when pip installing firedrake (or some other downstream library). If `petsc4py` isn't in the isolated build environment then you get an unhelpful missing attribute error for `petsctools.init`, which doesn't explain why `init` is missing`.