### PR TITLE
Provide set of converged reasons for each PETSc object type

### DIFF
--- a/petsctools/__init__.py
+++ b/petsctools/__init__.py
@@ -32,6 +32,14 @@ if PETSC4PY_INSTALLED:
         is_set_from_options,
         inserted_options,
     )
+    from .reasons import (  # noqa: F401
+        PCReasons,
+        KSPReasons,
+        SNESReasons,
+        TAOReasons,
+        TAOLineSearchReasons,
+        TSReasons,
+    )
 else:
 
     def __getattr__(name):
@@ -49,6 +57,12 @@ else:
             "set_from_options",
             "is_set_from_options",
             "inserted_options",
+            "PCReasons",
+            "KSPReasons",
+            "SNESReasons",
+            "TAOReasons",
+            "TAOLineSearchReasons",
+            "TSReasons",
         }
         if name in petsc4py_attrs:
             raise ImportError(

--- a/petsctools/reasons.py
+++ b/petsctools/reasons.py
@@ -1,0 +1,14 @@
+from petsc4py import PETSc
+
+
+def _make_reasons(reasons):
+    return {getattr(reasons, r): r
+            for r in dir(reasons) if not r.startswith('_')}
+
+
+PCReasons = _make_reasons(PETSc.PC.FailedReason())
+KSPReasons = _make_reasons(PETSc.KSP.ConvergedReason())
+SNESReasons = _make_reasons(PETSc.SNES.ConvergedReason())
+TAOReasons = _make_reasons(PETSc.TAO.ConvergedReason())
+TAOLineSearchReasons = _make_reasons(PETSc.TAOLineSearch.Reason())
+TSReasons = _make_reasons(PETSc.TS.ConvergedReason())


### PR DESCRIPTION
Firedrake has `KSPReasons` and `SNESReasons`, and the TAO solve in pyadjoint has `TAOReasons`. We may as well provide the full set here for everyone to use.